### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/cmd.c
+++ b/src/cmd.c
@@ -1848,7 +1848,7 @@ static int _cmd_menu_grep_cb(cmd_context_t* ctx, char * action) {
     return EON_OK;
   }
 
-  if (colon + 1 != '\0' && strchr(colon + 1, ':') != NULL) {
+  if (*(colon + 1) != '\0' && strchr(colon + 1, ':') != NULL) {
     linenum = strtoll(colon + 1, NULL, 10);
 
   } else {
@@ -1947,7 +1947,9 @@ static int _cmd_menu_browse_cb(cmd_context_t* ctx, char * action) {
     return EON_ERR;
   }
 
-  getcwd(cwd, PATH_MAX);
+  if (getcwd(cwd, PATH_MAX) == NULL) {
+    strcpy(cwd, ".");
+  }
 
   if (strcmp(cwd, ctx->bview->init_cwd) != 0) {
     res = asprintf(&corrected_path, "%s/%s", ctx->bview->init_cwd, path);


### PR DESCRIPTION
```
$ gcc --version
gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0
```
```
src/cmd.c:1851:17: warning: comparison between pointer and zero character constant [-Wpointer-compare]
 1851 |   if (colon + 1 != '\0' && strchr(colon + 1, ':') != NULL) {
      |                 ^~
src/cmd.c:1851:7: note: did you mean to dereference the pointer?
 1851 |   if (colon + 1 != '\0' && strchr(colon + 1, ':') != NULL) {
      |       ^
src/cmd.c: In function ‘_cmd_menu_browse_cb’:
src/cmd.c:1950:3: warning: ignoring return value of ‘getcwd’, declared with attribute warn_unused_result [-Wunused-result]
 1950 |   getcwd(cwd, PATH_MAX);
      |   ^~~~~~~~~~~~~~~~~~~~~
```
The former seemed like a legit bug. However, I am less sure about how to handle the latter. I simply copied "." into `cwd` just to do _something_, but perhaps the better thing would be to error here.