### PR TITLE
Open browse view to the working directory of the currently open bview.

### DIFF
--- a/src/bview.c
+++ b/src/bview.c
@@ -23,6 +23,11 @@ static void _bview_highlight_bracket_pair(bview_t* self, mark_t* mark);
 
 // Create a new bview
 bview_t* bview_new(editor_t* editor, char* opt_path, int opt_path_len, buffer_t* opt_buffer) {
+  return bview_new_cwd(editor, opt_path, opt_path_len, NULL, opt_buffer);
+}
+
+// Create a new bview with a working directory
+bview_t* bview_new_cwd(editor_t* editor, char* opt_path, int opt_path_len, const char* opt_cwd, buffer_t* opt_buffer) {
   bview_t* self;
   buffer_t* buffer;
 
@@ -43,8 +48,11 @@ bview_t* bview_new(editor_t* editor, char* opt_path, int opt_path_len, buffer_t*
   self->viewport_scope_x = editor->viewport_scope_x;
   self->viewport_scope_y = editor->viewport_scope_y;
 
-  char * res;
-  res = getcwd(self->init_cwd, PATH_MAX + 1);
+  if (opt_cwd != NULL) {
+    strncpy(self->init_cwd, opt_cwd, sizeof(self->init_cwd) - 1);
+  } else {
+    char* res = getcwd(self->init_cwd, sizeof(self->init_cwd));
+  }
 
   if (opt_buffer) { // Open buffer
     buffer = opt_buffer;

--- a/src/cmd.c
+++ b/src/cmd.c
@@ -36,6 +36,7 @@ static int _cmd_indent_line(bline_t* bline, int use_tabs, int outdent, int col);
 static void _cmd_help_inner(char* buf, kbinding_t* trie, str_t* h);
 static void _cmd_insert_smart_newline(cmd_context_t* ctx);
 static void _cmd_insert_smart_closing_bracket(cmd_context_t* ctx);
+static int _cmd_browse(cmd_context_t* ctx);
 
 // Insert data
 int cmd_insert_data(cmd_context_t* ctx) {
@@ -930,6 +931,27 @@ int cmd_ctag(cmd_context_t* ctx) {
 
 // Browse directory via tree
 int cmd_browse(cmd_context_t* ctx) {
+  char cwd[PATH_MAX] = {0};
+  char* cr;
+  int r;
+
+  // Set the initial browse path to the current bview's working directory
+  if (ctx->bview->init_cwd[0]) {
+    cr = getcwd(cwd, sizeof(cwd));
+    r = chdir(ctx->bview->init_cwd);
+  }
+
+  int ret = _cmd_browse(ctx);
+
+  // Restore the previous cwd
+  if (cwd[0]) {
+    r = chdir(cwd);
+  }
+
+  return ret;
+}
+
+int _cmd_browse(cmd_context_t* ctx) {
   bview_t* menu;
   async_proc_t* aproc;
   char* cmd;
@@ -1972,7 +1994,7 @@ static int _cmd_menu_browse_cb(cmd_context_t* ctx, char * action) {
     // debug("Opening dir: %s\n", corrected_path);
     res = chdir(corrected_path);
     ctx->bview = ctx->editor->active_edit;
-    cmd_browse(ctx);
+    _cmd_browse(ctx);
   } else {
     // debug("Opening file: %s\n", corrected_path);
     editor_open_bview(ctx->editor, NULL, EON_BVIEW_TYPE_EDIT, corrected_path, strlen(corrected_path), 0, 0, &ctx->editor->rect_edit, NULL, &new_bview);

--- a/src/editor.c
+++ b/src/editor.c
@@ -2,6 +2,7 @@
 #include <signal.h>
 #include <time.h>
 #include <termbox.h>
+#include <libgen.h>
 #include "uthash.h"
 #include "utlist.h"
 #include "eon.h"
@@ -385,7 +386,13 @@ int editor_open_bview(editor_t* editor, bview_t* parent, int type, char* opt_pat
   // Make new bview if not already open
   if (!found) {
     // debug("Initializing bview with path: %s\n", opt_path);
-    bview = bview_new(editor, opt_path, opt_path_len, opt_buffer);
+    char* opt_cwd = NULL, *path_cpy = NULL;
+    if (opt_path != NULL) {
+      path_cpy = strdup(opt_path);
+      opt_cwd = dirname(path_cpy);
+    }
+
+    bview = bview_new_cwd(editor, opt_path, opt_path_len, opt_cwd, opt_buffer);
     bview->type = type;
     CDL_APPEND2(editor->all_bviews, bview, all_prev, all_next);
     if (!parent) {
@@ -393,6 +400,8 @@ int editor_open_bview(editor_t* editor, bview_t* parent, int type, char* opt_pat
     } else {
       parent->split_child = bview;
     }
+
+    free(path_cpy);
   }
 
   if (make_active) {

--- a/src/eon.h
+++ b/src/eon.h
@@ -385,6 +385,7 @@ int editor_add_binding_to_keymap(editor_t* editor, kmap_t* kmap, kbinding_def_t*
 // bview functions
 bview_t* bview_get_split_root(bview_t* self);
 bview_t* bview_new(editor_t* editor, char* opt_path, int opt_path_len, buffer_t* opt_buffer);
+bview_t* bview_new_cwd(editor_t* editor, char* opt_path, int opt_path_len, const char* opt_cwd, buffer_t* opt_buffer);
 int bview_add_cursor_asleep(bview_t* self, bline_t* bline, bint_t col, cursor_t** optret_cursor);
 int bview_add_cursor(bview_t* self, bline_t* bline, bint_t col, cursor_t** optret_cursor);
 int bview_add_listener(bview_t* self, bview_listener_cb_t callback, void* udata);


### PR DESCRIPTION
I feel like this speeds up navigation in most cases.

One potentially controversial change is that this now sets the default cwd of new bviews to the parent directory of the file being opened. I hope this doesn't have any bad side-effects!